### PR TITLE
Kubernetes controllers

### DIFF
--- a/kubernetes-controllers/frontend-deployment.yaml
+++ b/kubernetes-controllers/frontend-deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - image: codecomrade/otus-kuber:microservices-demo-frontend
+        imagePullPolicy: Always
+        name: server
+        readinessProbe:
+          initialDelaySeconds: 10
+          httpGet:
+            path: "/_healthz"
+            port: 8080
+            httpHeaders:
+            - name: "Cookie"
+              value: "shop_session-id=x-readiness-probe"
+        resources: {}
+        env:
+        - name: PORT
+          value: "8080"
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"
+        - name: ENV_PLATFORM
+          value: "gcp"

--- a/kubernetes-controllers/frontend-replicaset.yaml
+++ b/kubernetes-controllers/frontend-replicaset.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - image: codecomrade/otus-kuber:microservices-demo-frontend-v2
+        imagePullPolicy: Always
+        name: server
+        resources: {}
+        env:
+        - name: PORT
+          value: "8080"
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"
+        - name: ENV_PLATFORM
+          value: "gcp"

--- a/kubernetes-controllers/paymentservice-deployment-bg.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-bg.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate: 
+      maxSurge: 100%
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - image: codecomrade/otus-kuber:microservices-demo-paymentservice-v2
+        imagePullPolicy: Always
+        name: server
+        resources: {}

--- a/kubernetes-controllers/paymentservice-deployment-reverse.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-reverse.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate: 
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - image: codecomrade/otus-kuber:microservices-demo-paymentservice-v2
+        imagePullPolicy: Always
+        name: server
+        resources: {}

--- a/kubernetes-controllers/paymentservice-deployment.yaml
+++ b/kubernetes-controllers/paymentservice-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - image: codecomrade/otus-kuber:microservices-demo-paymentservice-v2
+        imagePullPolicy: Always
+        name: server
+        resources: {}

--- a/kubernetes-controllers/paymentservice-replicaset.yaml
+++ b/kubernetes-controllers/paymentservice-replicaset.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - image: codecomrade/otus-kuber:microservices-demo-paymentservice-v2
+        imagePullPolicy: Always
+        name: server
+        resources: {}

--- a/kubernetes-controllers/rollout-log-bg.txt
+++ b/kubernetes-controllers/rollout-log-bg.txt
@@ -1,0 +1,19 @@
+paymentservice-66cc87cffb-b6w27   0/1     Pending               v2
+paymentservice-66cc87cffb-6g6qd   0/1     Pending               v2
+paymentservice-66cc87cffb-stkm7   0/1     Pending               v2
+paymentservice-66cc87cffb-b6w27   0/1     ContainerCreating     v2
+paymentservice-66cc87cffb-6g6qd   0/1     ContainerCreating     v2
+paymentservice-66cc87cffb-stkm7   0/1     ContainerCreating     v2
+
+paymentservice-66cc87cffb-b6w27   1/1     Running               v2
+paymentservice-859d7cb97-vxqb5    1/1     Terminating           v1
+
+paymentservice-66cc87cffb-6g6qd   1/1     Running               v2
+paymentservice-859d7cb97-nb52c    1/1     Terminating           v1
+
+paymentservice-66cc87cffb-stkm7   1/1     Running               v2
+paymentservice-859d7cb97-6j55p    1/1     Terminating           v1
+
+paymentservice-859d7cb97-vxqb5    0/1     Terminating           v1
+paymentservice-859d7cb97-nb52c    0/1     Terminating           v1
+paymentservice-859d7cb97-6j55p    0/1     Terminating           v1

--- a/kubernetes-controllers/rollout-log-default.txt
+++ b/kubernetes-controllers/rollout-log-default.txt
@@ -1,0 +1,18 @@
+paymentservice-66cc87cffb-2ld96   0/1     Pending               v2
+paymentservice-66cc87cffb-2ld96   0/1     ContainerCreating     v2
+paymentservice-66cc87cffb-2ld96   1/1     Running               v2
+paymentservice-859d7cb97-6tjjv    1/1     Terminating           v1
+
+paymentservice-66cc87cffb-qpqmc   0/1     Pending               v2
+paymentservice-66cc87cffb-qpqmc   0/1     ContainerCreating     v2
+paymentservice-66cc87cffb-qpqmc   1/1     Running               v2
+paymentservice-859d7cb97-76qcp    1/1     Terminating           v1
+
+paymentservice-66cc87cffb-z26bq   0/1     Pending               v2
+paymentservice-66cc87cffb-z26bq   0/1     ContainerCreating     v2
+paymentservice-66cc87cffb-z26bq   1/1     Running               v2
+paymentservice-859d7cb97-94hr4    1/1     Terminating           v1
+
+paymentservice-859d7cb97-6tjjv    0/1     Terminating           v1
+paymentservice-859d7cb97-94hr4    0/1     Terminating           v1
+paymentservice-859d7cb97-76qcp    0/1     Terminating           v1

--- a/kubernetes-controllers/rollout-log-reverse.txt
+++ b/kubernetes-controllers/rollout-log-reverse.txt
@@ -1,0 +1,18 @@
+paymentservice-859d7cb97-cqljf    1/1     Terminating           v1
+paymentservice-66cc87cffb-9h2zw   0/1     Pending               v2
+paymentservice-66cc87cffb-9h2zw   0/1     ContainerCreating     v2
+paymentservice-66cc87cffb-9h2zw   1/1     Running               v2
+
+paymentservice-859d7cb97-x4zt5    1/1     Terminating           v1
+paymentservice-66cc87cffb-2xbrh   0/1     Pending               v2
+paymentservice-66cc87cffb-2xbrh   0/1     ContainerCreating     v2
+paymentservice-66cc87cffb-2xbrh   1/1     Running               v2
+
+paymentservice-859d7cb97-8d4bn    1/1     Terminating           v1
+paymentservice-66cc87cffb-b62tx   0/1     Pending               v2
+paymentservice-66cc87cffb-b62tx   0/1     ContainerCreating     v2
+paymentservice-66cc87cffb-b62tx   1/1     Running               v2
+
+paymentservice-859d7cb97-x4zt5    0/1     Terminating           v1
+paymentservice-859d7cb97-8d4bn    0/1     Terminating           v1
+paymentservice-859d7cb97-cqljf    0/1     Terminating           v1

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    run: frontend
+    app: frontend
   name: frontend
 spec:
   containers:

--- a/kubernetes-intro/frontend-pod.yaml
+++ b/kubernetes-intro/frontend-pod.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    run: frontend
+    app: frontend
   name: frontend
 spec:
   containers:


### PR DESCRIPTION
# Выполнено ДЗ № 2

 - [x] Основное ДЗ
 - [x] Задание со * (частично, только blue-green и reverse strategy)

## В процессе сделано:

- Ответ про ReplicaSet (слайд 6): не хватало условия выборки подов, за которыми должна следить реплика. Добавил `selector: matchLabels: app: frontend`
- Поигрался со скейлингом реплики, круто
- `-o jsonpath` не зашел. Понимаю, что в некоторых случаях без него никак, но `jq` приятней. Добавил в табличку-список подов в терминале новую колонку с образом и тегом вот таким параметром `-o custom-columns=" . . . . ,IMAGE:.spec.containers[0].image"`
- Ответ про ReplicaSet (слайд 12): реплика смотрит только только на метку `app: frontend`, и ни на что кроме этого единственного тега реплика не обращает внимания.
- Сделал развертывания для blue-green и для reverse strategy. не уверен, что правильно, руководствовался только логикой и не гуглил. Еще я дополнительно записал лог состояния подов при обновлении трех разных деплойментов: смотри файлы `rollout-log-default.txt`, `rollout-log-bg.txt`, `rollout-log-reverse.txt`
- Выполнил задания с пробами, все отписанные ситуации воспроизводились, но вот с отслеживанием статуса не_разворачивающегося деплоймента еще надо разобраться по-глубже

Вот опубликованные образы, использованные в манифестах

```
codecomrade/otus-kuber:microservices-demo-frontend
codecomrade/otus-kuber:microservices-demo-frontend-v2
codecomrade/otus-kuber:microservices-demo-paymentservice-v1
codecomrade/otus-kuber:microservices-demo-paymentservice-v2
```

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
